### PR TITLE
Add FindTypesOf

### DIFF
--- a/interface_queryer.go
+++ b/interface_queryer.go
@@ -1,0 +1,17 @@
+package apitools
+
+import (
+	"strings"
+)
+
+// FindTypesOf finds resources that match a particular interface.
+func FindTypesOf[T any]() []T {
+	result := []T{}
+	IterTypes(func(group, name string, resource any) bool {
+		if t, ok := resource.(T); ok && strings.ToLower(name) != name {
+			result = append(result, t)
+		}
+		return true
+	})
+	return result
+}

--- a/resolver.go
+++ b/resolver.go
@@ -123,3 +123,30 @@ func semverGreater(s1, s2 string) bool {
 	}
 	return s1Ver.GT(s2Ver)
 }
+
+func copyTypeMap() map[string]map[string]typeRef {
+	typeMapMu.Lock()
+	defer typeMapMu.Unlock()
+	mapCopy := make(map[string]map[string]typeRef, len(typeMap))
+	for k, v := range typeMap {
+		inner := map[string]typeRef{}
+		for kk, vv := range v {
+			inner[kk] = vv
+		}
+		mapCopy[k] = inner
+	}
+	return mapCopy
+}
+
+// IterTypes iterates a copy of the typemap, calling fn for each type, with the
+// API group, type name, and type.
+func IterTypes(fn func(apiGroup, typename string, t any) (cont bool)) {
+	mapCopy := copyTypeMap()
+	for k, v := range mapCopy {
+		for kk, vv := range v {
+			if !fn(k, kk, vv.new()) {
+				return
+			}
+		}
+	}
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -8,9 +8,17 @@ import (
 	apitools "github.com/sensu/sensu-api-tools"
 )
 
-func TestResolveType(t *testing.T) {
-	type TestAPITypeA struct{}
-	type TestAPITypeB struct{ T string }
+type TestAPITypeA struct{}
+
+func (*TestAPITypeA) Foo() {}
+
+type TestAPITypeB struct{ T string }
+
+func (*TestAPITypeB) Foo() {}
+
+type TestAPITypeC struct{}
+
+func init() {
 	apitools.RegisterType("apis_test/v1", new(TestAPITypeA))
 	apitools.RegisterType("apis_test/v1", new(TestAPITypeB))
 	apitools.RegisterType("apis_test/v2", new(TestAPITypeA), apitools.WithAlias("test_api_type_a", "kazoo"))
@@ -19,6 +27,10 @@ func TestResolveType(t *testing.T) {
 			b.T = "flute"
 		}
 	}))
+	apitools.RegisterType("apis_test/v1", new(TestAPITypeC))
+}
+
+func TestResolveType(t *testing.T) {
 	testCases := []struct {
 		ApiVersion string
 		Type       string
@@ -82,5 +94,31 @@ func TestResolveType(t *testing.T) {
 				t.Fatal("expected an error")
 			}
 		})
+	}
+}
+
+func TestIterTypes(t *testing.T) {
+	i := 0
+	apitools.IterTypes(func(apiGroup, name string, _ any) bool {
+		i++
+		if _, err := apitools.Resolve(apiGroup, name); err != nil {
+			t.Error(err)
+		}
+		return true
+	})
+	// expect 7 types, since we alias rbac names
+	if got, want := i, 7; got != want {
+		t.Errorf("didn't iterate all types: got %d, want %d", got, want)
+	}
+}
+
+func TestFindTypesOf(t *testing.T) {
+	type Fooer interface {
+		Foo()
+	}
+
+	result := apitools.FindTypesOf[Fooer]()
+	if got, want := len(result), 4; got != want {
+		t.Errorf("wrong number of results: got %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
FindTypesOf can be used to find API types that implement a particular interface.