### PR TITLE
bugfix: Fix issue with version resolver

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -103,7 +103,7 @@ func Resolve(apiVersion string, typename string) (interface{}, error) {
 
 	if foundVer, err := versionOf(ref.Type); err == nil {
 		if semverGreater(reqVer, foundVer) {
-			return nil, fmt.Errorf("requested version was %s, but only %s is available", reqVer, foundVer)
+			return nil, fmt.Errorf("requested version of %s was %s, but only %s is available", typename, reqVer, foundVer)
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where the version resolver does not respect path boundaries. Currently it incorrectly resolves a version for a type in package `github.com/sensu/a-b/api` from the version published for the module `github.com/sensu/a`.